### PR TITLE
I have not a primary key as 'id' and have error during set action one();

### DIFF
--- a/models/Element.php
+++ b/models/Element.php
@@ -43,7 +43,7 @@ class Element extends \yii\db\ActiveRecord
         $modelStr = $this->model;
         $productModel = new $modelStr();
         
-        return $this->hasOne($productModel::className(), ['id' => 'item_id'])->one();
+        return $this->hasOne($productModel::className(), [$productModel->getPrimaryKey() => 'item_id'])->one();
     }
     
     public function getOrder()


### PR DESCRIPTION
Ошибка возникала при создании заказа одной кнопкой. У меня в товарах primary key = product_id, и при попытке получения экземпляра модели была ошибка об отсутствующем столбце в таблице товаров.
В модели товара я добавил на всякий случай еще и  такое
`public function getPrimaryKey($asArray = false)
    {
        return static::getTableSchema()->primaryKey;
    }`